### PR TITLE
`Deno.run` is deprecated and replaced to `Deno.Command`

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -3,7 +3,6 @@ import { assertEquals } from "https://deno.land/std@0.87.0/testing/asserts.ts";
 
 Deno.test({
   name: "Get Version",
-  sanitizeResources: false,
   async fn() {
     assertEquals(typeof (await getVersion()), "string");
   },
@@ -11,7 +10,6 @@ Deno.test({
 
 Deno.test({
   name: "Get Languages",
-  sanitizeResources: false,
   async fn() {
     assertEquals(typeof (await getLanguages()), "object");
   },
@@ -19,7 +17,6 @@ Deno.test({
 
 Deno.test({
   name: "Recognize",
-  sanitizeResources: false,
   async fn() {
     assertEquals((await recognize("testdata/deno.png")).trim(), "Deno");
   },
@@ -27,7 +24,6 @@ Deno.test({
 
 Deno.test({
   name: "Recognize with language options",
-  sanitizeResources: false,
   async fn() {
     assertEquals(
       (await recognize("testdata/deno.png", {


### PR DESCRIPTION
Hello, `Deno.Run` has been deprecated. So I replaced to `Deno.Command`. Also, with this, the `sanitizeResources` option in the test.ts no longer needs to be specified, so it has been removed.

ref: https://deno.land/api@v1.43.3?s=Deno.run